### PR TITLE
qrdecode: fix error where float was used as a string index

### DIFF
--- a/yubioath/gui/qrdecode.py
+++ b/yubioath/gui/qrdecode.py
@@ -263,7 +263,7 @@ def parse_bits(bits, version):
         while l > 0:
             if l >= 2:
                 num, bits = bits_to_int(bits[:11]), bits[11:]
-                buf += ALPHANUM[num / 45]
+                buf += ALPHANUM[num // 45]
                 buf += ALPHANUM[num % 45]
                 l -= 2
             else:


### PR DESCRIPTION
We needed to do an integer division not a float division.

Signed-off-by: Steven Noonan steven@uplinklabs.net
